### PR TITLE
[250604] 일정 API 전체 구현: 내 일정, 친구/공개 일정 조회

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,13 +2,15 @@ require('dotenv').config();
 const express       = require('express');
 const cookieParser  = require('cookie-parser');
 const userRoutes    = require('./src/routes/user.routes');
+const scheduleRoutes    = require('./src/routes/schedule.routes');
 
 const app  = express();
 const port = process.env.PORT || 3000;
 
 app.use(cookieParser());
 app.use(express.json());
-app.use('/', userRoutes);   // 또는 '/api'
+app.use('/', userRoutes);
+app.use('/', scheduleRoutes);
 
 
 app.listen(port, () => {

--- a/backend/src/controllers/schedule.controller.js
+++ b/backend/src/controllers/schedule.controller.js
@@ -1,0 +1,59 @@
+const {
+  getSchedulesByUser,
+  getScheduleById,
+  createSchedule,
+  updateSchedule,
+  deleteSchedule,
+} = require('../models/schedule.model');
+
+/* 내 일정 목록 */
+exports.getMySchedules = async (req, res) => {
+  const source = req.query.source;
+  try {
+    const rows = await getSchedulesByUser(req.user.id, source);
+    // id 숨기기
+    const events = rows.map(({ id, ...rest }) => rest);
+    res.json(events);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: '일정 조회 실패' });
+  }
+};
+
+/* 일정 생성 */
+exports.createSchedule = async (req, res) => {
+  const { title, description, source, start_date, end_date } = req.body;
+  if (!title || !start_date || !end_date)
+    return res.status(400).json({ message: '필수 값 누락' });
+
+  try {
+    const id = await createSchedule(req.user.id, {
+      title, description, source, start_date, end_date,
+    });
+    const event = await getScheduleById(id, req.user.id);
+    const { id: _ignored, user_id, created_at, ...publicEvent } = event;
+    res.status(201).json({ message: '일정 생성', event: publicEvent });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: '일정 생성 실패' });
+  }
+};
+
+/* 일정 수정 */
+exports.updateSchedule = async (req, res) => {
+  const { id } = req.params;
+  const changed = await updateSchedule(id, req.user.id, req.body);
+  if (!changed) return res.status(404).json({ message: '일정 없음' });
+
+  const event = await getScheduleById(id, req.user.id);
+  const { id: _ignored, user_id, created_at, ...publicEvent } = event;
+  res.json({ message: '수정 완료', event: publicEvent });
+};
+
+/* 일정 삭제 */
+exports.deleteSchedule = async (req, res) => {
+  const { id } = req.params;
+  const ok = await deleteSchedule(id, req.user.id);
+  if (!ok) return res.status(404).json({ message: '일정 없음' });
+  res.json({ message: '삭제 완료' });
+};

--- a/backend/src/models/schedule.model.js
+++ b/backend/src/models/schedule.model.js
@@ -1,0 +1,95 @@
+const getConnection = require('../db');
+
+// 날짜 ↔ 문자열 변환 유틸
+const formatDate = d => new Date(d).toISOString().slice(0, 10);
+
+/* 목록 조회 */
+async function getSchedulesByUser(userId, source) {
+  const conn = await getConnection();
+  let sql = `
+    SELECT id, title, description, source, start_date, end_date
+    FROM calc
+    WHERE user_id = ?`;
+  const params = [userId];
+
+  if (['manual', 'contest'].includes(source)) {
+    sql += ' AND source = ?';
+    params.push(source);
+  }
+
+  const [rows] = await conn.query(sql, params);
+  await conn.end();
+  return rows.map(r => ({
+    // id는 컨트롤러에서 제거
+    ...r,
+    start_date: formatDate(r.start_date),
+    end_date:   formatDate(r.end_date),
+  }));
+}
+
+/* 단일 일정 조회 (수정/삭제용) */
+async function getScheduleById(id, userId) {
+  const conn = await getConnection();
+  const [rows] = await conn.query(
+    'SELECT * FROM calc WHERE id = ? AND user_id = ? LIMIT 1',
+    [id, userId]
+  );
+  await conn.end();
+  return rows[0] || null;
+}
+
+/* 일정 생성 */
+async function createSchedule(userId, payload) {
+  const conn = await getConnection();
+  const [rs] = await conn.query(
+    `INSERT INTO calc (user_id, title, description, source, start_date, end_date)
+     VALUES (?,?,?,?,?,?)`,
+    [
+      userId,
+      payload.title,
+      payload.description || null,
+      payload.source || 'manual',
+      payload.start_date,
+      payload.end_date,
+    ]
+  );
+  await conn.end();
+  return rs.insertId; // 새로 생성된 PK 반환
+}
+
+/* 일정 수정 */
+async function updateSchedule(id, userId, fields) {
+  const columns = ['title', 'description', 'source', 'start_date', 'end_date'];
+  const keys = Object.keys(fields).filter(k => columns.includes(k));
+  if (!keys.length) return false;
+
+  const sets = keys.map(k => `${k} = ?`).join(', ');
+  const vals = keys.map(k => fields[k]).concat(id, userId);
+
+  const conn = await getConnection();
+  const [rs] = await conn.query(
+    `UPDATE calc SET ${sets} WHERE id = ? AND user_id = ?`,
+    vals
+  );
+  await conn.end();
+  return rs.affectedRows > 0;
+}
+
+/* 일정 삭제 */
+async function deleteSchedule(id, userId) {
+  const conn = await getConnection();
+  const [rs] = await conn.query(
+    'DELETE FROM calc WHERE id = ? AND user_id = ?',
+    [id, userId]
+  );
+  await conn.end();
+  return rs.affectedRows > 0;
+}
+
+module.exports = {
+  getSchedulesByUser,
+  getScheduleById,
+  createSchedule,
+  updateSchedule,
+  deleteSchedule,
+};

--- a/backend/src/routes/schedule.routes.js
+++ b/backend/src/routes/schedule.routes.js
@@ -1,0 +1,10 @@
+const router  = require('express').Router();
+const auth    = require('../middlewares/auth');
+const ctrl    = require('../controllers/schedule.controller');
+
+router.get('/calendar',           auth, ctrl.getMySchedules);
+router.post('/calendar',          auth, ctrl.createSchedule);
+router.patch('/calendar/:id',     auth, ctrl.updateSchedule);
+router.delete('/calendar/:id',    auth, ctrl.deleteSchedule);
+
+module.exports = router;


### PR DESCRIPTION
### PR 타입  
- [x] 기능 추가  
- [ ] 기능 삭제  
- [ ] 버그 수정  
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트  

---

### 변경 사항  
- 내 일정 관련 API
  - GET /calendar
  - POST /calendar
  - PATCH /calendar/:id
  - DELETE /calendar/:id  
- 친구 일정 조회 API  
  - GET /friends/:username/schedules  
- 공개 계정 일정 조회 API  
  - GET /users/:username/schedules  
- 응답 포맷: 일정 목록에서 id 필드 제거

---

### 전달 사항  
- 친구 일정은 친구 관계일 경우에만 조회 가능 (403 처리 포함)  
- 공개 일정은 사용자 계정이 is_public=true 일 때만 조회 가능  
