### PR TITLE
[240607] 로그인/회원가입/로그아웃 핸들러 useAuth 훅으로 리팩토링

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,30 +1,17 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React from "react";
 import { Header } from "./components/Header/Header";
 import Footer from "./components/Footer/Footer";
 import AppRoutes from "./routes/routes";
+import { useAuth } from "./hooks/useAuth";
 
 const App: React.FC = () => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const navigate = useNavigate();
-
-  const handleLoginClick = () => {
-    navigate("/login");
-  };
-
-  const handleSignupClick = () => {
-    navigate("/signup");
-  };
-
-  const handleLoginSuccess = () => {
-    setIsAuthenticated(true);
-    navigate("/");
-  };
-
-  const handleLogoutClick = () => {
-    setIsAuthenticated(false);
-    navigate("/");
-  };
+  const {
+    isAuthenticated,
+    handleLoginClick,
+    handleSignupClick,
+    handleLoginSuccess,
+    handleLogoutClick,
+  } = useAuth();
 
   return (
     <>
@@ -34,7 +21,6 @@ const App: React.FC = () => {
         onSignupClick={handleSignupClick}
         onLogoutClick={handleLogoutClick}
       />
-
       <main className="pt-4">
         <AppRoutes />
       </main>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export function useAuth() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const navigate = useNavigate();
+
+  const handleLoginClick = () => navigate("/login");
+  const handleSignupClick = () => navigate("/signup");
+  const handleLoginSuccess = () => {
+    setIsAuthenticated(true);
+    navigate("/");
+  };
+  const handleLogoutClick = () => {
+    setIsAuthenticated(false);
+    navigate("/");
+  };
+
+  return {
+    isAuthenticated,
+    handleLoginClick,
+    handleSignupClick,
+    handleLoginSuccess,
+    handleLogoutClick,
+  };
+}

--- a/frontend/src/pages/calendar/index.tsx
+++ b/frontend/src/pages/calendar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
@@ -10,15 +10,16 @@ import "../../styles/FullCalendar.css";
 const FILTERS = ["전체", "공모전", "자격증", "코딩테스트", "개인"];
 
 const CalendarPage: React.FC = () => {
-  const [selected, setSelected] = useState<string>("전체");
+  const [selected, setSelected] = useState("전체");
 
-  const handleAddSchedule = () => {
+  const handleAddSchedule = useCallback(() => {
     alert("일정 추가 폼/모달이 열립니다!");
-    // 실제로는 모달 상태를 true로 바꾸고, 모달 컴포넌트 띄우기
-  };
+    // TODO: 일정 추가 모달 상태 관리
+  }, []);
 
   return (
     <div className="flex max-w-6xl mx-auto p-6 gap-6 select-none">
+      {/* 좌측: 필터/일정추가 */}
       <aside className="w-52">
         <div className="bg-white rounded-lg shadow p-4 flex flex-col gap-4">
           <AddScheduleButton onClick={handleAddSchedule} />
@@ -29,7 +30,8 @@ const CalendarPage: React.FC = () => {
           />
         </div>
       </aside>
-      <section className="flex-1 min-w-0 bg-white rounded-lg shadow p-4 select-none">
+      {/* 우측: 캘린더 */}
+      <section className="flex-1 min-w-0 bg-white rounded-lg shadow p-4">
         <FullCalendar
           plugins={[dayGridPlugin, timeGridPlugin]}
           initialView="dayGridMonth"


### PR DESCRIPTION
<!--
머지 제목은 항상 다음과 같은 규칙을 지킨다.
[날짜] 해당 Merge와 관련된 큰 제목
ex) [240806] 학습한 강의 수 저장 기능
머지 내용은 아래 템플릿을 복사해서 사용한다.
-->

### PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 리팩토링

### 변경 사항
- App.tsx의 로그인/로그아웃/회원가입 핸들러를 useAuth 커스텀 훅으로 분리
- 인증 상태 및 관련 함수들을 useAuth 훅에서 관리하도록 구조 개선

### 전달 사항
- 추후 인증 API 연동 시 useAuth 훅만 수정하면 전체 앱에 쉽게 적용 가능