### PR TITLE
[250612] 단방향 쿼리 양방향으로 수정 및 친구 정보 API 추가

### DIFF
--- a/backend/src/controllers/friend.controller.js
+++ b/backend/src/controllers/friend.controller.js
@@ -8,6 +8,7 @@ const {
   getFriends,
   deleteFriend,
   getUserIdByUsername,
+  getFriendByUsername,
 } = require("../models/friend.model");
 
 /** 친구 요청 보내기 */
@@ -192,5 +193,24 @@ exports.deleteFriend = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "친구 삭제 실패" });
+  }
+};
+
+/** 친구 정보 조회 */
+exports.getFriendByUsername = async (req, res) => {
+  const myId = req.user.id;
+  const { username } = req.params;
+
+  try {
+    const friend = await getFriendByUsername(myId, username);
+
+    if (!friend) {
+      return res.status(404).json({ message: '친구가 아니거나 존재하지 않는 사용자입니다.' });
+    }
+
+    res.json(friend);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: '친구 정보 조회 중 오류가 발생했습니다.' });
   }
 };

--- a/backend/src/models/friend.model.js
+++ b/backend/src/models/friend.model.js
@@ -113,6 +113,21 @@ async function getUserIdByUsername(username) {
   return rows[0]?.id || null;
 }
 
+/** 친구 username으로 친구 정보 조회 (로그인한 사용자 기준) */
+async function getFriendByUsername(userId, friendUsername) {
+  const conn = await getConnection();
+  const [rows] = await conn.query(
+    `SELECT u.id, u.username, u.nickname, u.profile_image
+       FROM friends f
+       JOIN users u ON u.id = f.friend_id
+      WHERE f.user_id = ? AND u.username = ? AND f.status = 'accepted'
+      LIMIT 1`,
+    [userId, friendUsername]
+  );
+  await conn.end();
+  return rows[0] || null;
+}
+
 module.exports = {
   addFriendRequest,
   getFriendRequestById,
@@ -123,4 +138,5 @@ module.exports = {
   getFriends,
   deleteFriend,
   getUserIdByUsername,
+  getFriendByUsername,
 };

--- a/backend/src/routes/friend.routes.js
+++ b/backend/src/routes/friend.routes.js
@@ -10,4 +10,3 @@ router.delete("/friends/:username", auth, ctrl.deleteFriend);
 router.get('/friends/:username', auth, ctrl.getFriendByUsername);
 
 module.exports = router;
-zjsxmfhffj

--- a/backend/src/routes/friend.routes.js
+++ b/backend/src/routes/friend.routes.js
@@ -7,5 +7,7 @@ router.get("/friends/received", auth, ctrl.receivedFriends);
 router.patch("/friends/:username", auth, ctrl.acceptFriend);
 router.get("/friends", auth, ctrl.getFriends);
 router.delete("/friends/:username", auth, ctrl.deleteFriend);
+router.get('/friends/:username', auth, ctrl.getFriendByUsername);
 
 module.exports = router;
+zjsxmfhffj


### PR DESCRIPTION
<!--
머지 제목은 항상 다음과 같은 규칙을 지킨다.
[날짜] 해당 Merge와 관련된 큰 제목
ex) [240806] 학습한 강의 수 저장 기능
머지 내용은 아래 템플릿을 복사해서 사용한다.
-->

### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 친구 일정 조회 API에서 친구 관계 확인 쿼리를 단방향에서 양방향으로 수정
- 상대방이 친구 요청을 보냈고 내가 수락한 경우에도 정상적으로 일정이 조회되도록 쿼리 로직 개선
- 친구 확인 용도로 쓰일 친구의 정보를 보는 API가 없었기 때문에 추가

### 전달 사항
