### PR TITLE
[250612] 친구 일정 username 라우팅 & .map 로직 수정

### DIFF
--- a/frontend/src/pages/friends/FriendCalendar.tsx
+++ b/frontend/src/pages/friends/FriendCalendar.tsx
@@ -25,13 +25,16 @@ interface FriendInfo {
 
 const FriendCalendar: React.FC = () => {
   // URL 파라미터에서 friendId를 가져옵니다.
-  const { friendId } = useParams<{ friendId: string }>();
+  const { username } = useParams<{ username: string }>();
   const navigate = useNavigate();
 
   // useFriendStore에서 캘린더 가져오기 함수를 가져옵니다.
   const { getFriendCalendar } = useFriendStore();
   // useAuthStore에서 인증 상태를 가져옵니다.
   const { isAuthenticated, user } = useAuthStore(); // 현재 로그인 사용자 정보도 필요할 수 있음
+
+
+
 
   // 상태 관리
   const [friendCalendarEvents, setFriendCalendarEvents] = useState<FriendCalendarEntry[]>([]);
@@ -47,7 +50,7 @@ const FriendCalendar: React.FC = () => {
     }
 
     // friendId가 없을 경우 에러 처리
-    if (!friendId) {
+    if (!username) {
       setError("친구 ID가 제공되지 않았습니다.");
       setLoading(false);
       return;
@@ -62,14 +65,15 @@ const FriendCalendar: React.FC = () => {
         // 이 부분은 `FriendList`에서 `Maps`할 때 `state`로 넘겨주거나,
         // 별도의 `useFriendStore` 함수를 추가하여 친구 목록에서 가져오는 것이 더 효율적일 수 있습니다.
         // 여기서는 임시로 API 호출을 가정합니다.
-        // **주의: 이 API는 백엔드 명세에 없으므로 백엔드와 확인이 필요합니다.**
-        const friendRes = await api.get(`/users/${friendId}`);
+        
+        const friendRes = await api.get(`/friends/${username}`);
         setFriendInfo(friendRes.data);
 
         // 2. 친구의 공개된 캘린더 일정 불러오기
-        // **주의: 이 API는 백엔드 명세에 없으므로 백엔드와 확인이 필요합니다.**
-        const events = await getFriendCalendar(parseInt(friendId));
-        setFriendCalendarEvents(events);
+        
+        const events = await getFriendCalendar(username);
+        console.log('[FriendCalendar] events from API:', events);
+        setFriendCalendarEvents(Array.isArray(events) ? events : []);
 
       } catch (err: any) {
         console.error('친구 캘린더 또는 친구 정보 불러오기 실패:', err.response?.data || err.message);
@@ -82,7 +86,7 @@ const FriendCalendar: React.FC = () => {
     };
 
     fetchFriendDataAndCalendar();
-  }, [isAuthenticated, friendId, navigate, getFriendCalendar]); // 의존성 배열에 모든 외부 변수 포함
+  }, [isAuthenticated, username, navigate, getFriendCalendar]); // 의존성 배열에 모든 외부 변수 포함
 
   // 로딩, 에러, 친구 정보 없음 상태 처리
   if (loading) {

--- a/frontend/src/pages/friends/FriendCalendar.tsx
+++ b/frontend/src/pages/friends/FriendCalendar.tsx
@@ -24,7 +24,7 @@ interface FriendInfo {
 }
 
 const FriendCalendar: React.FC = () => {
-  // URL 파라미터에서 friendId를 가져옵니다.
+  // URL 파라미터에서 username을 가져옵니다.
   const { username } = useParams<{ username: string }>();
   const navigate = useNavigate();
 
@@ -51,7 +51,7 @@ const FriendCalendar: React.FC = () => {
 
     // friendId가 없을 경우 에러 처리
     if (!username) {
-      setError("친구 ID가 제공되지 않았습니다.");
+      setError("친구 username이 제공되지 않았습니다.");
       setLoading(false);
       return;
     }

--- a/frontend/src/pages/friends/FriendList.tsx
+++ b/frontend/src/pages/friends/FriendList.tsx
@@ -183,7 +183,7 @@ const FriendList: React.FC = () => {
                   </div>
                   <div className="flex gap-2"> {/* 버튼들을 감싸는 div 추가 */}
                     <button
-                      onClick={() => navigate(`/friends/${friend.id}/calendar`)} // 친구 캘린더 페이지로 이동
+                      onClick={() => navigate(`/friends/${friend.username}/schedule`)} // 친구 캘린더 페이지로 이동
                       className="px-4 py-2 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-600 transition text-sm shadow-md"
                     >
                       캘린더 보기

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -31,7 +31,7 @@ const AppRoutes: React.FC = () => (
 
     {/* 친구 관련 라우트 추가 및 경로 설정 */}
     <Route path="/friends" element={<FriendList />} /> {/* 친구 목록 및 친구 추가/요청 관리 페이지 */}
-    <Route path="/friends/:friendId/calendar" element={<FriendCalendar />} /> {/* 특정 친구의 캘린더 보기 페이지 */}
+    <Route path="/friends/:username/schedule" element={<FriendCalendar />} /> {/* 특정 친구의 캘린더 보기 페이지 */}
   </Routes>
 );
 

--- a/frontend/src/store/useFriendStore.ts
+++ b/frontend/src/store/useFriendStore.ts
@@ -43,7 +43,7 @@ interface FriendState {
   sendFriendRequest: (targetUsername: string) => Promise<void>;
   handleFriendRequest: (senderUsername: string, action: 'accept' | 'reject') => Promise<void>; // 수락/거절 통합
   removeFriend: (friendUsername: string) => Promise<void>; // 친구 삭제 // <--- 추가
-  getFriendCalendar: (friendId: number) => Promise<FriendCalendarEntry[]>;
+  getFriendCalendar: (username: string) => Promise<FriendCalendarEntry[]>;
 }
 
 export const useFriendStore = create<FriendState>((set, get) => ({
@@ -135,14 +135,13 @@ export const useFriendStore = create<FriendState>((set, get) => ({
 
   // 캘린더 관련 API는 기존과 유사
   // (API 명세에 따로 언급이 없었지만, `/friends/:friendId/calendar`는 유지한다고 가정)
-  getFriendCalendar: async (friendId: number) => {
-    try {
-      // 명세에는 없지만, 친구의 캘린더는 친구 ID로 가져온다고 가정
-      const response = await api.get(`/friends/${friendId}/calendar`);
-      return response.data; // FriendCalendarEntry[] 반환
-    } catch (error) {
-      console.error(`친구 (${friendId}) 캘린더 불러오기 실패:`, error);
-      throw error;
-    }
-  },
+  getFriendCalendar: async (username) => {
+  try {
+    const response = await api.get(`/friends/${username}/schedules`);
+    return response.data.schedules || []; // 배열만 반환
+  } catch (error) {
+    console.error(`친구 (${username}) 캘린더 불러오기 실패:`, error);
+    return []; // 실패 시 빈 배열 반환
+  }
+},
 }));


### PR DESCRIPTION
<!--
머지 제목은 항상 다음과 같은 규칙을 지킨다.
[날짜] 해당 Merge와 관련된 큰 제목
ex) [240806] 학습한 강의 수 저장 기능
머지 내용은 아래 템플릿을 복사해서 사용한다.
-->

### PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- ID ⇒ username 전환
- 프론트 라우터 경로 /friends/:username/schedule 로 통일
- .map 처리 개선
- 빈 배열 대응 로직 추가로 일정이 없을 때도 오류 방지

### 전달 사항
